### PR TITLE
fix compatibility with Phing 3.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,11 +12,11 @@
     }
   ],
   "require": {
-    "php": ">= 7.1"
+    "php": ">= 7.1",
+    "tedivm/jshrink": "^1.3"
   },
   "require-dev": {
-    "phing/phing": "3.0.x-dev",
-    "tedivm/jshrink": "^1.3"
+    "phing/phing": "3.0.x-dev"
   },
   "autoload": {
     "psr-4": {


### PR DESCRIPTION
jsmin task from phing-3.0.0-RC3.phar failed, because tedivm/jshrink not included in phar.

In this PR:

* "tedivm/jshrink" moved to required dependensies
* fixed imports for Phing's  namespaces